### PR TITLE
Feature/basic authentication with users in memory or db

### DIFF
--- a/API.http
+++ b/API.http
@@ -30,3 +30,8 @@ GET http://localhost:8080/api/v1/products
 Authorization: Basic user2 password
 ###
 
+#@no-cookie-jar
+GET http://localhost:8080/api/v1/products
+Authorization: Basic admin password
+###
+

--- a/click-and-collect/src/main/java/fr/ul/miage/clickandcollect/core/SecurityProperties.java
+++ b/click-and-collect/src/main/java/fr/ul/miage/clickandcollect/core/SecurityProperties.java
@@ -1,0 +1,22 @@
+package fr.ul.miage.clickandcollect.core;
+
+import fr.ul.miage.clickandcollect.core.auth.UsersStorage;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import static fr.ul.miage.clickandcollect.core.auth.UsersStorage.IN_MEMORY;
+
+@Component
+@ConfigurationProperties("app.security")
+public class SecurityProperties {
+
+    private UsersStorage storage = IN_MEMORY;
+
+    public UsersStorage getStorage() {
+        return storage;
+    }
+
+    public void setStorage(UsersStorage storage) {
+        this.storage = storage;
+    }
+}

--- a/click-and-collect/src/main/java/fr/ul/miage/clickandcollect/core/WebSecurityConfig.java
+++ b/click-and-collect/src/main/java/fr/ul/miage/clickandcollect/core/WebSecurityConfig.java
@@ -1,0 +1,60 @@
+package fr.ul.miage.clickandcollect.core;
+
+import fr.ul.miage.clickandcollect.core.auth.DBAuthProvider;
+import fr.ul.miage.clickandcollect.core.auth.MD5Checker;
+import fr.ul.miage.clickandcollect.core.auth.UserDetailsServiceFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.builders.WebSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+
+import static fr.ul.miage.clickandcollect.core.auth.UsersStorage.DB;
+import static org.springframework.http.HttpMethod.GET;
+import static org.springframework.http.HttpMethod.OPTIONS;
+
+// https://spring.io/guides/gs/securing-web/
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
+
+    private final SecurityProperties        properties;
+    private final UserDetailsServiceFactory detailsFactory;
+
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+        // https://stackoverflow.com/a/14020466/1107450
+        // jetbrains://idea/settings?name=Editor--Code+Style
+        // Enable format markers
+        http
+                .csrf().disable()
+                .authorizeRequests()
+                .antMatchers("/").permitAll()
+                .antMatchers("/actuator/info").permitAll()
+                .antMatchers("/actuator/health").permitAll()
+                .antMatchers("/api").permitAll()
+                .antMatchers("/api/v1.yml").permitAll()
+                .antMatchers("/webjars/**").permitAll()
+                .anyRequest()
+                .authenticated();
+
+        // https://dzone.com/articles/spring-security-authentication
+        if (properties.getStorage() == DB) {
+            final var authProvider = new DBAuthProvider(detailsFactory.inDb(), new MD5Checker());
+            http.authenticationProvider(authProvider);
+        } else {
+            http.userDetailsService(detailsFactory.inMemory());
+        }
+
+        http.httpBasic();
+    }
+
+    @Override
+    public void configure(WebSecurity web) throws Exception {
+        web.ignoring()
+                .antMatchers(OPTIONS, "/**")
+                .antMatchers(GET, "/favicon.ico");
+    }
+}

--- a/click-and-collect/src/main/java/fr/ul/miage/clickandcollect/core/auth/AuthFailException.java
+++ b/click-and-collect/src/main/java/fr/ul/miage/clickandcollect/core/auth/AuthFailException.java
@@ -1,0 +1,10 @@
+package fr.ul.miage.clickandcollect.core.auth;
+
+import org.springframework.security.core.AuthenticationException;
+
+public class AuthFailException extends AuthenticationException {
+
+    public AuthFailException() {
+        super("The provided username or password are not correct");
+    }
+}

--- a/click-and-collect/src/main/java/fr/ul/miage/clickandcollect/core/auth/DBAuthProvider.java
+++ b/click-and-collect/src/main/java/fr/ul/miage/clickandcollect/core/auth/DBAuthProvider.java
@@ -1,0 +1,38 @@
+package fr.ul.miage.clickandcollect.core.auth;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.userdetails.UserDetailsService;
+
+@RequiredArgsConstructor
+public class DBAuthProvider implements AuthenticationProvider {
+
+    private final UserDetailsService detailsService;
+    private final PasswordChecker    checker;
+
+    @Override
+    public Authentication authenticate(Authentication authentication) throws AuthenticationException {
+        if(authentication.getCredentials() == null) {
+            return null;
+        }
+
+        final var details = detailsService.loadUserByUsername(authentication.getPrincipal().toString());
+
+        if(checker.areEqual(details.getPassword(), authentication.getCredentials().toString())) {
+            final var token = (UsernamePasswordAuthenticationToken) authentication;
+
+            // need to re-create because : Cannot set this token to trusted - use constructor which takes a GrantedAuthority list instead
+            return new UsernamePasswordAuthenticationToken(token.getPrincipal(), details.getPassword(), details.getAuthorities());
+        }
+
+        throw new AuthFailException();
+    }
+
+    @Override
+    public boolean supports(Class<?> authentication) {
+        return authentication.equals(UsernamePasswordAuthenticationToken.class);
+    }
+}

--- a/click-and-collect/src/main/java/fr/ul/miage/clickandcollect/core/auth/DBUserDetailsService.java
+++ b/click-and-collect/src/main/java/fr/ul/miage/clickandcollect/core/auth/DBUserDetailsService.java
@@ -1,0 +1,30 @@
+package fr.ul.miage.clickandcollect.core.auth;
+
+import fr.ul.miage.clickandcollect.users.User;
+import fr.ul.miage.clickandcollect.users.UsersRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+
+import static org.springframework.security.core.userdetails.User.withUsername;
+
+@RequiredArgsConstructor
+public class DBUserDetailsService implements UserDetailsService {
+
+    private final UsersRepository repository;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        User user = repository
+                .findByUsername(username)
+                .orElseThrow(AuthFailException::new);
+
+        // https://docs.spring.io/spring-security/site/docs/4.2.15.RELEASE/apidocs/org/springframework/security/core/userdetails/User.html#withDefaultPasswordEncoder--
+
+        return withUsername(user.getUsername())
+                .password(user.getPassword())
+                .roles(user.getRole())
+                .build();
+    }
+}

--- a/click-and-collect/src/main/java/fr/ul/miage/clickandcollect/core/auth/MD5Checker.java
+++ b/click-and-collect/src/main/java/fr/ul/miage/clickandcollect/core/auth/MD5Checker.java
@@ -1,0 +1,27 @@
+package fr.ul.miage.clickandcollect.core.auth;
+
+import lombok.SneakyThrows;
+
+import javax.xml.bind.DatatypeConverter;
+import java.security.MessageDigest;
+
+public class MD5Checker implements PasswordChecker {
+
+    @SneakyThrows
+    public MD5Checker() {
+        // If this will fail, the app should not boot, it will not work in any case
+        MessageDigest.getInstance("MD5");
+    }
+
+    @SneakyThrows
+    // https://www.baeldung.com/java-md5
+    public boolean areEqual(String source, String target) {
+        MessageDigest md = MessageDigest.getInstance("MD5");
+        md.update(target.getBytes());
+        byte[] digest = md.digest();
+        String targetEnc = DatatypeConverter.printHexBinary(digest).toUpperCase();
+
+        return source.equalsIgnoreCase(targetEnc);
+    }
+
+}

--- a/click-and-collect/src/main/java/fr/ul/miage/clickandcollect/core/auth/PasswordChecker.java
+++ b/click-and-collect/src/main/java/fr/ul/miage/clickandcollect/core/auth/PasswordChecker.java
@@ -1,0 +1,7 @@
+package fr.ul.miage.clickandcollect.core.auth;
+
+public interface PasswordChecker {
+
+    boolean areEqual(String source, String target);
+
+}

--- a/click-and-collect/src/main/java/fr/ul/miage/clickandcollect/core/auth/UserDetailsServiceFactory.java
+++ b/click-and-collect/src/main/java/fr/ul/miage/clickandcollect/core/auth/UserDetailsServiceFactory.java
@@ -1,0 +1,38 @@
+package fr.ul.miage.clickandcollect.core.auth;
+
+import fr.ul.miage.clickandcollect.users.UsersRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class UserDetailsServiceFactory {
+
+    private final UsersRepository userRepository;
+    private final PasswordEncoder encoder = PasswordEncoderFactories.createDelegatingPasswordEncoder();
+
+    public UserDetailsService inDb() {
+        return new DBUserDetailsService(userRepository);
+    }
+
+    public UserDetailsService inMemory() {
+        // https://docs.spring.io/spring-security/site/docs/4.2.15.RELEASE/apidocs/org/springframework/security/core/userdetails/User.html#withDefaultPasswordEncoder--
+        UserDetails user = User.withUsername("user")
+                .password(encoder.encode("password"))
+                .roles("USER")
+                .build();
+
+        UserDetails admin = User.withUsername("admin")
+                .password(encoder.encode("password"))
+                .roles("ADMIN")
+                .build();
+
+        return new InMemoryUserDetailsManager(user, admin);
+    }
+}

--- a/click-and-collect/src/main/java/fr/ul/miage/clickandcollect/core/auth/UsersStorage.java
+++ b/click-and-collect/src/main/java/fr/ul/miage/clickandcollect/core/auth/UsersStorage.java
@@ -1,0 +1,5 @@
+package fr.ul.miage.clickandcollect.core.auth;
+
+public enum UsersStorage {
+    IN_MEMORY, DB
+}

--- a/click-and-collect/src/main/java/fr/ul/miage/clickandcollect/users/User.java
+++ b/click-and-collect/src/main/java/fr/ul/miage/clickandcollect/users/User.java
@@ -1,0 +1,26 @@
+package fr.ul.miage.clickandcollect.users;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import javax.persistence.*;
+
+@Entity
+@Table(name = "USERS", schema = "clickandcollect")
+@Setter
+@Getter
+@NoArgsConstructor
+public class User {
+
+    @Id
+    @GeneratedValue(strategy= GenerationType.IDENTITY)
+    private Long id;
+
+    private String username;
+
+    private String password;
+
+    private String role;
+
+}

--- a/click-and-collect/src/main/java/fr/ul/miage/clickandcollect/users/UsersRepository.java
+++ b/click-and-collect/src/main/java/fr/ul/miage/clickandcollect/users/UsersRepository.java
@@ -1,0 +1,13 @@
+package fr.ul.miage.clickandcollect.users;
+
+import org.springframework.data.repository.PagingAndSortingRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface UsersRepository extends PagingAndSortingRepository<User, Long> {
+
+    Optional<User> findByUsername(String username);
+
+}

--- a/click-and-collect/src/main/resources/db/changelog/v1/000_create_schema.xml
+++ b/click-and-collect/src/main/resources/db/changelog/v1/000_create_schema.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+
+    <changeSet id="1" author="rodi" dbms="h2">
+        <sql>
+            CREATE SCHEMA IF NOT EXISTS clickandcollect;
+        </sql>
+    </changeSet>
+
+</databaseChangeLog>

--- a/click-and-collect/src/main/resources/db/changelog/v1/001_create_table_product.xml
+++ b/click-and-collect/src/main/resources/db/changelog/v1/001_create_table_product.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+
+    <changeSet id="0" author="rodi">
+        <createTable tableName="product" schemaName="clickandcollect">
+            <column name="id" type="bigint" autoIncrement="true">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="name" type="varchar(250)"/>
+            <column name="description" type="varchar(1200)"/>
+        </createTable>
+    </changeSet>
+
+</databaseChangeLog>

--- a/click-and-collect/src/main/resources/db/changelog/v1/002_create_table_users.xml
+++ b/click-and-collect/src/main/resources/db/changelog/v1/002_create_table_users.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+
+    <changeSet id="0" author="rodi">
+        <createTable tableName="users" schemaName="clickandcollect">
+            <column name="id" type="bigint" autoIncrement="true">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="username" type="varchar(250)"/>
+            <column name="password" type="varchar(999)"/>
+            <column name="role" type="varchar(24)"/>
+        </createTable>
+    </changeSet>
+
+</databaseChangeLog>

--- a/click-and-collect/src/main/resources/db/changelog/v1/003_insert_users.xml
+++ b/click-and-collect/src/main/resources/db/changelog/v1/003_insert_users.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+
+<!--
+https://askubuntu.com/a/53852/50752
+
+$ echo -n password | md5sum
+-->
+
+    <changeSet id="0" author="rodi">
+        <insert tableName="users" schemaName="clickandcollect">
+            <column name="username" value="user"/>
+            <column name="password" value="5f4dcc3b5aa765d61d8327deb882cf99"/>
+            <column name="role" value="USER"/>
+        </insert>
+    </changeSet>
+
+    <changeSet id="1" author="rodi">
+        <insert tableName="users" schemaName="clickandcollect">
+            <column name="username" value="user2"/>
+            <column name="password" value="5f4dcc3b5aa765d61d8327deb882cf99"/>
+            <column name="role" value="USER"/>
+        </insert>
+    </changeSet>
+
+    <changeSet id="2" author="rodi">
+        <insert tableName="users" schemaName="clickandcollect">
+            <column name="username" value="admin"/>
+            <column name="password" value="5f4dcc3b5aa765d61d8327deb882cf99"/>
+            <column name="role" value="ADMIN"/>
+        </insert>
+    </changeSet>
+
+</databaseChangeLog>

--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,11 @@
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-security</artifactId>
+		</dependency>
+
+		<dependency>
 			<groupId>org.liquibase</groupId>
 			<artifactId>liquibase-core</artifactId>
 		</dependency>

--- a/src/main/java/tech/becoming/clickandcollect/app/core/SecurityProperties.java
+++ b/src/main/java/tech/becoming/clickandcollect/app/core/SecurityProperties.java
@@ -1,0 +1,22 @@
+package tech.becoming.clickandcollect.app.core;
+
+import tech.becoming.clickandcollect.app.core.auth.UsersStorage;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import static tech.becoming.clickandcollect.app.core.auth.UsersStorage.IN_MEMORY;
+
+@Component
+@ConfigurationProperties("app.security")
+public class SecurityProperties {
+
+    private UsersStorage storage = IN_MEMORY;
+
+    public UsersStorage getStorage() {
+        return storage;
+    }
+
+    public void setStorage(UsersStorage storage) {
+        this.storage = storage;
+    }
+}

--- a/src/main/java/tech/becoming/clickandcollect/app/core/WebSecurityConfig.java
+++ b/src/main/java/tech/becoming/clickandcollect/app/core/WebSecurityConfig.java
@@ -1,0 +1,60 @@
+package tech.becoming.clickandcollect.app.core;
+
+import tech.becoming.clickandcollect.app.core.auth.DBAuthProvider;
+import tech.becoming.clickandcollect.app.core.auth.MD5Checker;
+import tech.becoming.clickandcollect.app.core.auth.UserDetailsServiceFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.builders.WebSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+
+import static tech.becoming.clickandcollect.app.core.auth.UsersStorage.DB;
+import static org.springframework.http.HttpMethod.GET;
+import static org.springframework.http.HttpMethod.OPTIONS;
+
+// https://spring.io/guides/gs/securing-web/
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
+
+    private final SecurityProperties        properties;
+    private final UserDetailsServiceFactory detailsFactory;
+
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+        // https://stackoverflow.com/a/14020466/1107450
+        // jetbrains://idea/settings?name=Editor--Code+Style
+        // Enable format markers
+        http
+                .csrf().disable()
+                .authorizeRequests()
+                .antMatchers("/").permitAll()
+                .antMatchers("/actuator/info").permitAll()
+                .antMatchers("/actuator/health").permitAll()
+                .antMatchers("/api").permitAll()
+                .antMatchers("/api/v1.yml").permitAll()
+                .antMatchers("/webjars/**").permitAll()
+                .anyRequest()
+                .authenticated();
+
+        // https://dzone.com/articles/spring-security-authentication
+        if (properties.getStorage() == DB) {
+            final var authProvider = new DBAuthProvider(detailsFactory.inDb(), new MD5Checker());
+            http.authenticationProvider(authProvider);
+        } else {
+            http.userDetailsService(detailsFactory.inMemory());
+        }
+
+        http.httpBasic();
+    }
+
+    @Override
+    public void configure(WebSecurity web) throws Exception {
+        web.ignoring()
+                .antMatchers(OPTIONS, "/**")
+                .antMatchers(GET, "/favicon.ico");
+    }
+}

--- a/src/main/java/tech/becoming/clickandcollect/app/core/auth/AuthFailException.java
+++ b/src/main/java/tech/becoming/clickandcollect/app/core/auth/AuthFailException.java
@@ -1,0 +1,10 @@
+package tech.becoming.clickandcollect.app.core.auth;
+
+import org.springframework.security.core.AuthenticationException;
+
+public class AuthFailException extends AuthenticationException {
+
+    public AuthFailException() {
+        super("The provided username or password are not correct");
+    }
+}

--- a/src/main/java/tech/becoming/clickandcollect/app/core/auth/DBAuthProvider.java
+++ b/src/main/java/tech/becoming/clickandcollect/app/core/auth/DBAuthProvider.java
@@ -1,0 +1,38 @@
+package tech.becoming.clickandcollect.app.core.auth;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.userdetails.UserDetailsService;
+
+@RequiredArgsConstructor
+public class DBAuthProvider implements AuthenticationProvider {
+
+    private final UserDetailsService detailsService;
+    private final PasswordChecker    checker;
+
+    @Override
+    public Authentication authenticate(Authentication authentication) throws AuthenticationException {
+        if(authentication.getCredentials() == null) {
+            return null;
+        }
+
+        final var details = detailsService.loadUserByUsername(authentication.getPrincipal().toString());
+
+        if(checker.areEqual(details.getPassword(), authentication.getCredentials().toString())) {
+            final var token = (UsernamePasswordAuthenticationToken) authentication;
+
+            // need to re-create because : Cannot set this token to trusted - use constructor which takes a GrantedAuthority list instead
+            return new UsernamePasswordAuthenticationToken(token.getPrincipal(), details.getPassword(), details.getAuthorities());
+        }
+
+        throw new AuthFailException();
+    }
+
+    @Override
+    public boolean supports(Class<?> authentication) {
+        return authentication.equals(UsernamePasswordAuthenticationToken.class);
+    }
+}

--- a/src/main/java/tech/becoming/clickandcollect/app/core/auth/DBUserDetailsService.java
+++ b/src/main/java/tech/becoming/clickandcollect/app/core/auth/DBUserDetailsService.java
@@ -1,0 +1,30 @@
+package tech.becoming.clickandcollect.app.core.auth;
+
+import tech.becoming.clickandcollect.app.users.User;
+import tech.becoming.clickandcollect.app.users.UsersRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+
+import static org.springframework.security.core.userdetails.User.withUsername;
+
+@RequiredArgsConstructor
+public class DBUserDetailsService implements UserDetailsService {
+
+    private final UsersRepository repository;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        User user = repository
+                .findByUsername(username)
+                .orElseThrow(AuthFailException::new);
+
+        // https://docs.spring.io/spring-security/site/docs/4.2.15.RELEASE/apidocs/org/springframework/security/core/userdetails/User.html#withDefaultPasswordEncoder--
+
+        return withUsername(user.getUsername())
+                .password(user.getPassword())
+                .roles(user.getRole())
+                .build();
+    }
+}

--- a/src/main/java/tech/becoming/clickandcollect/app/core/auth/MD5Checker.java
+++ b/src/main/java/tech/becoming/clickandcollect/app/core/auth/MD5Checker.java
@@ -1,0 +1,27 @@
+package tech.becoming.clickandcollect.app.core.auth;
+
+import lombok.SneakyThrows;
+
+import javax.xml.bind.DatatypeConverter;
+import java.security.MessageDigest;
+
+public class MD5Checker implements PasswordChecker {
+
+    @SneakyThrows
+    public MD5Checker() {
+        // If this will fail, the app should not boot, it will not work in any case
+        MessageDigest.getInstance("MD5");
+    }
+
+    @SneakyThrows
+    // https://www.baeldung.com/java-md5
+    public boolean areEqual(String source, String target) {
+        MessageDigest md = MessageDigest.getInstance("MD5");
+        md.update(target.getBytes());
+        byte[] digest = md.digest();
+        String targetEnc = DatatypeConverter.printHexBinary(digest).toUpperCase();
+
+        return source.equalsIgnoreCase(targetEnc);
+    }
+
+}

--- a/src/main/java/tech/becoming/clickandcollect/app/core/auth/PasswordChecker.java
+++ b/src/main/java/tech/becoming/clickandcollect/app/core/auth/PasswordChecker.java
@@ -1,0 +1,7 @@
+package tech.becoming.clickandcollect.app.core.auth;
+
+public interface PasswordChecker {
+
+    boolean areEqual(String source, String target);
+
+}

--- a/src/main/java/tech/becoming/clickandcollect/app/core/auth/UserDetailsServiceFactory.java
+++ b/src/main/java/tech/becoming/clickandcollect/app/core/auth/UserDetailsServiceFactory.java
@@ -1,0 +1,38 @@
+package tech.becoming.clickandcollect.app.core.auth;
+
+import tech.becoming.clickandcollect.app.users.UsersRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class UserDetailsServiceFactory {
+
+    private final UsersRepository userRepository;
+    private final PasswordEncoder encoder = PasswordEncoderFactories.createDelegatingPasswordEncoder();
+
+    public UserDetailsService inDb() {
+        return new DBUserDetailsService(userRepository);
+    }
+
+    public UserDetailsService inMemory() {
+        // https://docs.spring.io/spring-security/site/docs/4.2.15.RELEASE/apidocs/org/springframework/security/core/userdetails/User.html#withDefaultPasswordEncoder--
+        UserDetails user = User.withUsername("user")
+                .password(encoder.encode("password"))
+                .roles("USER")
+                .build();
+
+        UserDetails admin = User.withUsername("admin")
+                .password(encoder.encode("password"))
+                .roles("ADMIN")
+                .build();
+
+        return new InMemoryUserDetailsManager(user, admin);
+    }
+}

--- a/src/main/java/tech/becoming/clickandcollect/app/core/auth/UsersStorage.java
+++ b/src/main/java/tech/becoming/clickandcollect/app/core/auth/UsersStorage.java
@@ -1,0 +1,5 @@
+package tech.becoming.clickandcollect.app.core.auth;
+
+public enum UsersStorage {
+    IN_MEMORY, DB
+}

--- a/src/main/java/tech/becoming/clickandcollect/app/users/User.java
+++ b/src/main/java/tech/becoming/clickandcollect/app/users/User.java
@@ -1,0 +1,26 @@
+package tech.becoming.clickandcollect.app.users;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import javax.persistence.*;
+
+@Entity
+@Table(name = "USERS", schema = "clickandcollect")
+@Setter
+@Getter
+@NoArgsConstructor
+public class User {
+
+    @Id
+    @GeneratedValue(strategy= GenerationType.IDENTITY)
+    private Long id;
+
+    private String username;
+
+    private String password;
+
+    private String role;
+
+}

--- a/src/main/java/tech/becoming/clickandcollect/app/users/UsersRepository.java
+++ b/src/main/java/tech/becoming/clickandcollect/app/users/UsersRepository.java
@@ -1,0 +1,13 @@
+package tech.becoming.clickandcollect.app.users;
+
+import org.springframework.data.repository.PagingAndSortingRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface UsersRepository extends PagingAndSortingRepository<User, Long> {
+
+    Optional<User> findByUsername(String username);
+
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,3 +5,5 @@ spring.datasource.username=sa
 spring.datasource.password=
 spring.datasource.url=jdbc:h2:tcp://localhost:9092/clickandcollect
 spring.datasource.driver-class-name=org.h2.Driver
+
+app.security.storage=db


### PR DESCRIPTION
In this change we clearly see that in order to add our custom basic authentication mechanism in DB, we need to create lots of files. 
The current implementation has support for both in memory and in db users storage.

We need to:
- manage the db
- manage the users
- manage the checking of users
- add dynamic configuration based on application.properties setting on where the users should be taken from